### PR TITLE
feat: Display version dynamically from app.json

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "dokidoki",
     "slug": "dokidoki",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "orientation": "portrait",
     "icon": "./assets/icon-dokidoki.png",
     "scheme": "frontend",

--- a/frontend/src/components/Dashboard/DashboardScreen.tsx
+++ b/frontend/src/components/Dashboard/DashboardScreen.tsx
@@ -32,6 +32,8 @@ import NotificationCard from "./Components/NotificationCard";
 import FeedbackCard from "./Components/FeedbackCard";
 import PostYourAnswerCard from "./Components/PostYourAnswerCard";
 import * as Notifications from "expo-notifications";
+import appConfig from "../../../app.json";
+
 type RootStackParamList = {
   Dashboard: undefined;
   PracticeSelect: undefined;
@@ -255,7 +257,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           </Text>
         </View>
         <View style={styles.versionContainer}>
-          <DisclaimerText text={"v1.3.0"} />
+          <DisclaimerText text={`v${appConfig.expo.version}`} />
         </View>
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
- Updated Dashboard to read version from app.json instead of hardcoded value
- Version now displays dynamically as v1.4.0

## Changes
- Imported app.json config in DashboardScreen
- Updated version display to use appConfig.expo.version

## Test plan
- [ ] Verify version displays correctly on Dashboard
- [ ] Test that version updates when app.json version changes